### PR TITLE
module names were not in line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # perunauthorize-simplesamlphp-module
+
 Module for displaying users warning about unauthorized access to the services
 
-##Instalation
+## Installation
 
 Once you have installed SimpleSAMLphp, installing this module is very simple. First of all, you will need to download Composer if you haven't already. After installing Composer, just execute the following command in the root of your SimpleSAMLphp installation:
 
@@ -17,4 +18,4 @@ Once you have installed SimpleSAMLphp, installing this module is very simple. Fi
 ```
 2.Install perunauthorize-simplesamlphp-module
 
-`php composer.phar require cesnet/simplesamlphp-module-perunauthorize:dev-master`
+`php composer.phar require cesnet/perunauthorize-simplesamlphp-module:dev-master`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,15 @@
-# perunauthorize-simplesamlphp-module
+# simplesamlphp-module-perunauthorize
 
 Module for displaying users warning about unauthorized access to the services
 
 ## Installation
 
-Once you have installed SimpleSAMLphp, installing this module is very simple. First of all, you will need to download Composer if you haven't already. After installing Composer, just execute the following command in the root of your SimpleSAMLphp installation:
+Once you have installed SimpleSAMLphp, installing this module is very simple. First of all, you will need to download Composer if you haven't already. After installing Composer, just execute the following commands in the root of your SimpleSAMLphp installation:
 
-1.Add follows repository to composer.json
+1. Add repository for simplesamlphp-module-perunauthorize to composer.json
 
-```json
-    "repositories":[
-         {
-                 "type": "git",       
-                 "url": "https://github.com/CESNET/simplesamlphp-module-perunauthorize"      
-         }
-     ]
-```
-2.Install perunauthorize-simplesamlphp-module
+`php composer.phar config repositories.module-perunauthorize git https://github.com/CESNET/simplesamlphp-module-perunauthorize.git`
+
+2. Install simplesamlphp-module-perunauthorize
 
 `php composer.phar require cesnet/simplesamlphp-module-perunauthorize:dev-master`

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Once you have installed SimpleSAMLphp, installing this module is very simple. Fi
     "repositories":[
          {
                  "type": "git",       
-                 "url": "https://github.com/CESNET/proxystatistics-simplesamlphp-module.git"      
+                 "url": "https://github.com/CESNET/simplesamlphp-module-perunauthorize"      
          }
      ]
 ```
 2.Install perunauthorize-simplesamlphp-module
 
-`php composer.phar require cesnet/perunauthorize-simplesamlphp-module:dev-master`
+`php composer.phar require cesnet/simplesamlphp-module-perunauthorize:dev-master`

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "cesnet/simplesamlphp-module-perunauthorize",
+  "name": "cscfi/simplesamlphp-module-perunauthorize",
   "description": "A SimpleSAMLPHP module for authorize working with module Perun",
   "type": "simplesamlphp-module",
   "keywords": ["perun","simplesamlphp", "authorize"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "cscfi/simplesamlphp-module-perunauthorize",
+  "name": "cesnet/simplesamlphp-module-perunauthorize",
   "description": "A SimpleSAMLPHP module for authorize working with module Perun",
   "type": "simplesamlphp-module",
   "keywords": ["perun","simplesamlphp", "authorize"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "cscfi/perunauthorize-simplesamlphp-module",
+  "name": "cscfi/simplesamlphp-module-perunauthorize",
   "description": "A SimpleSAMLPHP module for authorize working with module Perun",
   "type": "simplesamlphp-module",
   "keywords": ["perun","simplesamlphp", "authorize"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "cesnet/simplesamlphp-module-perunauthorize",
+  "name": "cscfi/perunauthorize-simplesamlphp-module",
   "description": "A SimpleSAMLPHP module for authorize working with module Perun",
   "type": "simplesamlphp-module",
   "keywords": ["perun","simplesamlphp", "authorize"],


### PR DESCRIPTION
Seems that module installer complains about following

> package name must be on the form "VENDOR/simplesamlphp-module-MODULENAME

module names weren't in line so installation was impossible because of broken dependencies.

Ansible now manages to install perun and perunauthorize modules from CSCfi repos.