### PR TITLE
Naming confusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Module for displaying users warning about unauthorized access to the services
 Once you have installed SimpleSAMLphp, installing this module is very simple. First of all, you will need to download Composer if you haven't already. After installing Composer, just execute the following commands in the root of your SimpleSAMLphp installation:
 
 1. Add repository for simplesamlphp-module-perunauthorize to composer.json
+
 `php composer.phar config repositories.module-perunauthorize git https://github.com/CESNET/simplesamlphp-module-perunauthorize.git`
 
 2. Install simplesamlphp-module-perunauthorize
+
 `php composer.phar require cesnet/simplesamlphp-module-perunauthorize:dev-master`

--- a/README.md
+++ b/README.md
@@ -1,20 +1,13 @@
-# perunauthorize-simplesamlphp-module
+# simplesamlphp-module-perunauthorize
+
 Module for displaying users warning about unauthorized access to the services
 
-##Instalation
+## Installation
 
-Once you have installed SimpleSAMLphp, installing this module is very simple. First of all, you will need to download Composer if you haven't already. After installing Composer, just execute the following command in the root of your SimpleSAMLphp installation:
+Once you have installed SimpleSAMLphp, installing this module is very simple. First of all, you will need to download Composer if you haven't already. After installing Composer, just execute the following commands in the root of your SimpleSAMLphp installation:
 
-1.Add follows repository to composer.json
+1. Add repository for simplesamlphp-module-perunauthorize to composer.json
+`php composer.phar config repositories.module-perunauthorize git https://github.com/CESNET/simplesamlphp-module-perunauthorize.git`
 
-```json
-    "repositories":[
-         {
-                 "type": "git",       
-                 "url": "https://github.com/CESNET/proxystatistics-simplesamlphp-module.git"      
-         }
-     ]
-```
-2.Install perunauthorize-simplesamlphp-module
-
+2. Install simplesamlphp-module-perunauthorize
 `php composer.phar require cesnet/simplesamlphp-module-perunauthorize:dev-master`


### PR DESCRIPTION
I were little confused with the module namings. In url module name differs from the one used in readme's and composer configurations. I changed readme to use real module name. It would also be convenient to use it as a project name.

I also changed instruction to use 'composer config repositories' instead editing a composer file by hand.